### PR TITLE
Fix issue 63

### DIFF
--- a/tests/testthat/test_directorate_addition.R
+++ b/tests/testthat/test_directorate_addition.R
@@ -88,7 +88,8 @@ test_that("directorate is calculated correctly",{
 
  # Extract only the spell number and directorate
   result <- add_directorate_variable(dt) %>%
-    dplyr::select(spell_number, directorate)
+    dplyr::select(spell_number, directorate) %>%
+    dplyr::arrange(spell_number)
 
 
   result$spell_number <- as.character(result$spell_number)


### PR DESCRIPTION
Results were equal up to row order. Resolve problem by ensuring results are ordered by spell_number, as are the correct_answers, before expectation is evaluated.

Fixes #63 